### PR TITLE
add `all` function

### DIFF
--- a/lib/fart.dart
+++ b/lib/fart.dart
@@ -4,9 +4,10 @@
 library fart;
 
 export 'src/extension/Aggregate.dart';
+export 'src/extension/All.dart';
+export 'src/extension/Max.dart';
 export 'src/extension/Reverse.dart';
 export 'src/extension/Where.dart';
-export 'src/extension/Max.dart';
 export 'src/Fart.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/lib/src/extension/All.dart
+++ b/lib/src/extension/All.dart
@@ -1,0 +1,23 @@
+import 'package:fart/fart.dart';
+import 'package:fart/src/exception/ArgumentNullException.dart';
+import 'package:fart/src/utility/Tuple.dart';
+
+extension AllFart<T> on Iterable<T> {
+  bool All(bool Function(T t) test) {
+    if (this == null) {
+      throw ArgumentNullException('`source` cannot be `null`');
+    }
+
+    if (test == null) {
+      throw ArgumentNullException('`predicate` cannot be `null`');
+    }
+
+    for(final item in this) {
+      if (!test(item)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -1,0 +1,63 @@
+import 'package:fart/src/exception/ArgumentNullException.dart';
+import 'package:test/test.dart';
+import 'package:fart/fart.dart';
+
+void main() {
+  group('All', () {
+    group('Success Scenarios', () {
+      test('should work for non-empty collection of ints', () {
+        // arrange
+        final numbersOneThroughFour =
+            Iterable<int>.generate(4).map((n) => n + 1);
+        final isEven = (int n) => n % 2 == 0;
+        final isLowNumber = (int n) => n < 100;
+
+        // act
+        final actualEven = numbersOneThroughFour.All(isEven);
+        final actualHigh = numbersOneThroughFour.All(isLowNumber);
+
+        // assert
+        expect(actualEven, false);
+        expect(actualHigh, true);
+      });
+
+      test('empty list should always be true', () {
+        // arrange
+        const noFruits = [];
+        final alwaysTrue = (fruit) => true;
+
+        // act
+
+        final actual = noFruits.All((_) => false);
+
+        // assert
+        expect(actual, true);
+      });
+    });
+
+    group('Error Scenarios', () {
+      test('should throw an `ArgumentNullException` if the `source` is `null`',
+          () {
+        // arrange
+        const List<int> input = null;
+
+        // act
+        // assert
+        expect(() => input.All((t) => true),
+            throwsA(TypeMatcher<ArgumentNullException>()));
+      });
+
+      test(
+          'should throw an `ArgumentNullException` if the `predicate` is `null`',
+          () {
+        // arrange
+        const input = <int>[1, 2, 3, 4, 5];
+
+        // act
+        // assert
+        expect(() => input.All(null),
+            throwsA(TypeMatcher<ArgumentNullException>()));
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #54 

I also ordered the export list in `fart.dart` to keep my sanity.